### PR TITLE
Feature get planned races (Open Races)

### DIFF
--- a/your-race/src/main/java/es/codeurjc/mastercloudapps/your_race/rest/RaceResource.java
+++ b/your-race/src/main/java/es/codeurjc/mastercloudapps/your_race/rest/RaceResource.java
@@ -37,7 +37,7 @@ public class RaceResource {
 
     @GetMapping("/planned")
     public ResponseEntity<List<RaceDTO>> getPlannedRaces() {
-        return ResponseEntity.ok(raceService.findPlanned());
+        return ResponseEntity.ok(raceService.findPlannedRaces());
     }
 
     @GetMapping("/{id}")

--- a/your-race/src/main/java/es/codeurjc/mastercloudapps/your_race/rest/RaceResource.java
+++ b/your-race/src/main/java/es/codeurjc/mastercloudapps/your_race/rest/RaceResource.java
@@ -37,7 +37,7 @@ public class RaceResource {
 
     @GetMapping("/planned")
     public ResponseEntity<List<RaceDTO>> getPlannedRaces() {
-        return ResponseEntity.ok(Collections.emptyList());
+        return ResponseEntity.ok(raceService.findAll());
     }
 
     @GetMapping("/{id}")

--- a/your-race/src/main/java/es/codeurjc/mastercloudapps/your_race/rest/RaceResource.java
+++ b/your-race/src/main/java/es/codeurjc/mastercloudapps/your_race/rest/RaceResource.java
@@ -32,12 +32,12 @@ public class RaceResource {
         else
             return ResponseEntity.ok(raceService.findAll());
     }
-
+/*
    @GetMapping("/planned")
     public ResponseEntity<List<RaceDTO>> getPlannedRaces() {
         return ResponseEntity.ok(raceService.findPlannedRaces());
     }
-
+*/
     @GetMapping("/{id}")
     public ResponseEntity<RaceDTO> getRace(@PathVariable final Long id) {
         return ResponseEntity.ok(raceService.get(id));

--- a/your-race/src/main/java/es/codeurjc/mastercloudapps/your_race/rest/RaceResource.java
+++ b/your-race/src/main/java/es/codeurjc/mastercloudapps/your_race/rest/RaceResource.java
@@ -37,7 +37,7 @@ public class RaceResource {
 
     @GetMapping("/planned")
     public ResponseEntity<List<RaceDTO>> getPlannedRaces() {
-        return ResponseEntity.ok(raceService.findAll());
+        return ResponseEntity.ok(raceService.findPlanned());
     }
 
     @GetMapping("/{id}")

--- a/your-race/src/main/java/es/codeurjc/mastercloudapps/your_race/rest/RaceResource.java
+++ b/your-race/src/main/java/es/codeurjc/mastercloudapps/your_race/rest/RaceResource.java
@@ -6,18 +6,12 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import javax.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 
 @RestController
@@ -31,11 +25,15 @@ public class RaceResource {
     }
 
     @GetMapping
-    public ResponseEntity<List<RaceDTO>> getAllRaces() {
-        return ResponseEntity.ok(raceService.findAll());
+    public ResponseEntity<List<RaceDTO>> getAllRaces(@RequestParam boolean open) {
+
+        if (open)
+            return ResponseEntity.ok(raceService.findPlannedRaces());
+        else
+            return ResponseEntity.ok(raceService.findAll());
     }
 
-    @GetMapping("/planned")
+   @GetMapping("/planned")
     public ResponseEntity<List<RaceDTO>> getPlannedRaces() {
         return ResponseEntity.ok(raceService.findPlannedRaces());
     }

--- a/your-race/src/main/java/es/codeurjc/mastercloudapps/your_race/rest/RaceResource.java
+++ b/your-race/src/main/java/es/codeurjc/mastercloudapps/your_race/rest/RaceResource.java
@@ -3,6 +3,8 @@ package es.codeurjc.mastercloudapps.your_race.rest;
 import es.codeurjc.mastercloudapps.your_race.model.RaceDTO;
 import es.codeurjc.mastercloudapps.your_race.service.RaceService;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+
+import java.util.Collections;
 import java.util.List;
 import javax.validation.Valid;
 import org.springframework.http.HttpStatus;
@@ -31,6 +33,11 @@ public class RaceResource {
     @GetMapping
     public ResponseEntity<List<RaceDTO>> getAllRaces() {
         return ResponseEntity.ok(raceService.findAll());
+    }
+
+    @GetMapping("/planned")
+    public ResponseEntity<List<RaceDTO>> getPlannedRaces() {
+        return ResponseEntity.ok(Collections.emptyList());
     }
 
     @GetMapping("/{id}")

--- a/your-race/src/main/java/es/codeurjc/mastercloudapps/your_race/rest/RaceResource.java
+++ b/your-race/src/main/java/es/codeurjc/mastercloudapps/your_race/rest/RaceResource.java
@@ -28,16 +28,10 @@ public class RaceResource {
     public ResponseEntity<List<RaceDTO>> getAllRaces(@RequestParam boolean open) {
 
         if (open)
-            return ResponseEntity.ok(raceService.findPlannedRaces());
+            return ResponseEntity.ok(raceService.findOpenRaces());
         else
             return ResponseEntity.ok(raceService.findAll());
     }
-/*
-   @GetMapping("/planned")
-    public ResponseEntity<List<RaceDTO>> getPlannedRaces() {
-        return ResponseEntity.ok(raceService.findPlannedRaces());
-    }
-*/
     @GetMapping("/{id}")
     public ResponseEntity<RaceDTO> getRace(@PathVariable final Long id) {
         return ResponseEntity.ok(raceService.get(id));

--- a/your-race/src/main/java/es/codeurjc/mastercloudapps/your_race/service/InitializerDataService.java
+++ b/your-race/src/main/java/es/codeurjc/mastercloudapps/your_race/service/InitializerDataService.java
@@ -52,6 +52,9 @@ public class InitializerDataService {
         Race race3 = getRace3(organizer2);
         Race race4 = getRace4(organizer2);
 
+        Race raceClosed1 = getRaceClosed1(organizer1);
+        Race raceClosed2 = getRaceClosed2(organizer2);
+
         race1.setRaceRegistration(Registration.builder().registrationType(RegistrationType.BYDRAWING)
                 .registrationDate(LocalDateTime.of(2022, Month.OCTOBER,31, 9,0))
                 .registrationCost(500.00).build());
@@ -69,6 +72,15 @@ public class InitializerDataService {
                 .registrationCost(150.00).build());
 
 
+        raceClosed1.setRaceRegistration(Registration.builder().registrationType(RegistrationType.BYDRAWING)
+                .registrationDate(LocalDateTime.of(2021, Month.OCTOBER,31, 9,0))
+                .registrationCost(500.00).build());
+
+        raceClosed2.setRaceRegistration(Registration.builder().registrationType(RegistrationType.BYORDER)
+                .registrationDate(LocalDateTime.of(2022, Month.JANUARY,15, 9,0))
+                .registrationCost(150.00).build());
+
+
         Athlete athlete1 = Athlete.builder().name("Antonio").surname("Delgado").build();
         Athlete athlete2 = Athlete.builder().name("María").surname("Rodríguez").build();
         Athlete athlete3 = Athlete.builder().name("Clara").surname("Smith").build();
@@ -80,6 +92,9 @@ public class InitializerDataService {
         this.raceRepository.save(race2);
         this.raceRepository.save(race3);
         this.raceRepository.save(race4);
+
+        this.raceRepository.save(raceClosed1);
+        this.raceRepository.save(raceClosed2);
 
         this.athleteRepository.save(athlete1);
         this.athleteRepository.save(athlete2);
@@ -167,6 +182,46 @@ public class InitializerDataService {
                 .build();
 
         return race4;
+    }
+
+    private Race getRaceClosed1(Organizer organizer1) {
+        Race race = Race.builder()
+                .name("New York City Marathon - Edition of 2021")
+                .description("""
+                        The New York City Marathon is an annual marathon that courses through the five boroughs of New York City.
+                        It is the largest marathon in the world, with 53,627 finishers in 2019 and 98,247 applicants for the 2017 race
+                        """)
+                .date(LocalDateTime.of(2021, Month.NOVEMBER,6, 9,0))
+                .location("New York, NY, USA")
+                .distance(42.195)
+                .type("Running")
+                .applicationPeriod(ApplicationPeriod.builder()
+                        .initialDate(LocalDateTime.of(2021, Month.JANUARY,1,0,0))
+                        .lastDate(LocalDateTime.of(2021, Month.OCTOBER,31,23,59))
+                        .build())
+                .organizer(organizer1)
+                .build();
+        return race;
+    }
+
+    private Race getRaceClosed2(Organizer organizer2) {
+        Race race = Race.builder()
+                .name("101 kilómetros de Ronda - Marcha Individual - Edition of 2022")
+                .description("""
+                        Marcha trail de 101 kilómetros en 24 horas por la serranía de Ronda y alrededores, organizados 
+                        por el Club Deportivo La Legión 101 Km.
+                        """)
+                .date(LocalDateTime.of(2022, Month.MAY,13, 10,0))
+                .location("Ronda, Málaga, Spain")
+                .distance(101.0)
+                .type("Running")
+                .applicationPeriod(ApplicationPeriod.builder()
+                        .initialDate(LocalDateTime.of(2021, Month.NOVEMBER,1,0,0))
+                        .lastDate(LocalDateTime.of(2021, Month.DECEMBER,31,23,59))
+                        .build())
+                .organizer(organizer2)
+                .build();
+        return race;
     }
 
 }

--- a/your-race/src/main/java/es/codeurjc/mastercloudapps/your_race/service/RaceService.java
+++ b/your-race/src/main/java/es/codeurjc/mastercloudapps/your_race/service/RaceService.java
@@ -9,6 +9,9 @@ import es.codeurjc.mastercloudapps.your_race.repos.ApplicationPeriodRepository;
 import es.codeurjc.mastercloudapps.your_race.repos.OrganizerRepository;
 import es.codeurjc.mastercloudapps.your_race.repos.RaceRepository;
 import es.codeurjc.mastercloudapps.your_race.repos.RegistrationRepository;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.springframework.data.domain.Sort;
@@ -42,11 +45,19 @@ public class RaceService {
                 .toList();
     }
 
-    public List<RaceDTO> findPlanned() {
-        return raceRepository.findAll(Sort.by("id"))
+    public List<RaceDTO> findPlannedRaces() {
+
+        List<RaceDTO> plannedRacesDTO = new ArrayList<RaceDTO>();
+        List<RaceDTO> allRacesDTO =  raceRepository.findAll(Sort.by("id"))
                 .stream()
                 .map(race -> mapToDTO(race, new RaceDTO()))
                 .toList();
+        for (RaceDTO raceDTO : allRacesDTO) {
+           if (LocalDateTime.now().isBefore(raceDTO.getDate()))
+                plannedRacesDTO.add(raceDTO);
+        }
+
+        return plannedRacesDTO;
     }
 
     public RaceDTO get(final Long id) {

--- a/your-race/src/main/java/es/codeurjc/mastercloudapps/your_race/service/RaceService.java
+++ b/your-race/src/main/java/es/codeurjc/mastercloudapps/your_race/service/RaceService.java
@@ -42,6 +42,13 @@ public class RaceService {
                 .toList();
     }
 
+    public List<RaceDTO> findPlanned() {
+        return raceRepository.findAll(Sort.by("id"))
+                .stream()
+                .map(race -> mapToDTO(race, new RaceDTO()))
+                .toList();
+    }
+
     public RaceDTO get(final Long id) {
         return raceRepository.findById(id)
                 .map(race -> mapToDTO(race, new RaceDTO()))

--- a/your-race/src/main/java/es/codeurjc/mastercloudapps/your_race/service/RaceService.java
+++ b/your-race/src/main/java/es/codeurjc/mastercloudapps/your_race/service/RaceService.java
@@ -45,19 +45,19 @@ public class RaceService {
                 .toList();
     }
 
-    public List<RaceDTO> findPlannedRaces() {
+    public List<RaceDTO> findOpenRaces() {
 
-        List<RaceDTO> plannedRacesDTO = new ArrayList<RaceDTO>();
+        List<RaceDTO> openRacesDTO = new ArrayList<RaceDTO>();
         List<RaceDTO> allRacesDTO =  raceRepository.findAll(Sort.by("id"))
                 .stream()
                 .map(race -> mapToDTO(race, new RaceDTO()))
                 .toList();
         for (RaceDTO raceDTO : allRacesDTO) {
            if (LocalDateTime.now().isBefore(raceDTO.getDate()))
-                plannedRacesDTO.add(raceDTO);
+                openRacesDTO.add(raceDTO);
         }
 
-        return plannedRacesDTO;
+        return openRacesDTO;
     }
 
     public RaceDTO get(final Long id) {

--- a/your-race/src/test/java/es/codeurjc/mastercloudapps/your_race/domain/RaceTest.java
+++ b/your-race/src/test/java/es/codeurjc/mastercloudapps/your_race/domain/RaceTest.java
@@ -1,7 +1,13 @@
-package es.codeurjc.mastercloudapps.your_race.domain;
+
+
+
+package es.codeurjc.mastercloudapps.your_race.unit;
 
 import com.github.javafaker.Faker;
 import es.codeurjc.mastercloudapps.your_race.AbstractDatabaseTest;
+import es.codeurjc.mastercloudapps.your_race.domain.ApplicationPeriod;
+import es.codeurjc.mastercloudapps.your_race.domain.Race;
+import es.codeurjc.mastercloudapps.your_race.domain.Registration;
 import es.codeurjc.mastercloudapps.your_race.model.RegistrationType;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -9,7 +15,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
-
+import javax.persistence.Column;
 import java.time.LocalDateTime;
 import java.time.Month;
 
@@ -26,8 +32,8 @@ class RaceTest extends AbstractDatabaseTest {
     @Test
     @DisplayName("Can create Race with name and location")
     void createRaceWithNameAndLocation(){
-        String name = faker.esports().event();
-        String location = faker.address().fullAddress();
+        String name = "Test Race";
+        String location = "Santiago de Compostela";
         Race race = Race.builder()
                 .name(name)
                 .location(location)
@@ -41,10 +47,10 @@ class RaceTest extends AbstractDatabaseTest {
     @DisplayName("A race has at least the following data: name, description, date, location, distance, type, athleteCapacity, ApplicationPeriod, Registration")
     void checkRaceHasData()
     {
-        String name = faker.esports().event();
+        String name = "Test Race";
         String description = "A Test Race for testing";
         LocalDateTime date = LocalDateTime.of(2023, Month.MAY,13, 10,0);
-        String location = faker.address().fullAddress();
+        String location = "Santiago de Compostela";
         Double distance = 21.0975;
         String type = "Test";
         Integer athleteCapacity = 10000;
@@ -93,8 +99,8 @@ class RaceTest extends AbstractDatabaseTest {
     @Test
     void checkRaceIsValidNameAndLocation() {
         Race race1 = Race.builder()
-                .name(faker.esports().event())
-                .location(faker.address().fullAddress())
+                .name("Test Race")
+                .location("Santiago de Compostela")
                 .build();
 
         Assertions.assertTrue(race1.isValid());
@@ -108,8 +114,8 @@ class RaceTest extends AbstractDatabaseTest {
     @Test
     void checkRaceIsValidRegistrationType() {
         Race race = Race.builder()
-                .name(faker.esports().event())
-                .location(faker.address().fullAddress())
+                .name("Test Race")
+                .location("Santiago de Compostela")
                 .build();
 
         Registration registration = new Registration();
@@ -132,8 +138,8 @@ class RaceTest extends AbstractDatabaseTest {
     @Test
     void checkRaceIsValidAthleteCapacity(){
         Race race = Race.builder()
-                .name(faker.esports().event())
-                .location(faker.address().fullAddress())
+                .name("Test Race")
+                .location("Santiago de Compostela")
                 .build();
 
 
@@ -156,8 +162,8 @@ class RaceTest extends AbstractDatabaseTest {
     @Test
     void checkRaceIsValidDistance(){
         Race race = Race.builder()
-                .name(faker.esports().event())
-                .location(faker.address().fullAddress())
+                .name("Test Race")
+                .location("Santiago de Compostela")
                 .build();
         Assertions.assertTrue(race.isValid());
 
@@ -175,8 +181,8 @@ class RaceTest extends AbstractDatabaseTest {
     @Test
     void checkRaceIsValidConcurrentRequestThreshold(){
         Race race = Race.builder()
-                .name(faker.esports().event())
-                .location(faker.address().fullAddress())
+                .name("Test Race")
+                .location("Santiago de Compostela")
                 .build();
 
         Registration registration = new Registration();
@@ -221,8 +227,8 @@ class RaceTest extends AbstractDatabaseTest {
     @Test
     void checkRaceIsValidApplicationDate() {
         Race race = Race.builder()
-                .name(faker.esports().event())
-                .location(faker.address().fullAddress())
+                .name("Test Race")
+                .location("Santiago de Compostela")
                 .build();
 
         ApplicationPeriod applicationPeriod = new ApplicationPeriod();
@@ -253,8 +259,8 @@ class RaceTest extends AbstractDatabaseTest {
     void checkRaceIsValidDatesAreValid(){
 
         Race race = Race.builder()
-                .name(faker.esports().event())
-                .location(faker.address().fullAddress())
+                .name("Test Race")
+                .location("Santiago de Compostela")
                 .build();
 
 

--- a/your-race/src/test/java/es/codeurjc/mastercloudapps/your_race/rest/RaceResourceTest.java
+++ b/your-race/src/test/java/es/codeurjc/mastercloudapps/your_race/rest/RaceResourceTest.java
@@ -47,7 +47,8 @@ class RaceResourceTest extends AbstractDatabaseTest {
         when(raceService.findAll()).thenReturn(races);
 
         mvc.perform(get("/api/races")
-                        .contentType(MediaType.APPLICATION_JSON))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .param("open","false"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$", hasSize(2)))
                 .andExpect(jsonPath("$[0].name", equalTo("Ronda")));

--- a/your-race/src/test/java/es/codeurjc/mastercloudapps/your_race/usecase/AthleteUseCaseTest.java
+++ b/your-race/src/test/java/es/codeurjc/mastercloudapps/your_race/usecase/AthleteUseCaseTest.java
@@ -69,20 +69,14 @@ public class AthleteUseCaseTest extends AbstractDatabaseTest {
         raceRepository.save(plannedRace1);
         raceRepository.save(plannedRace2);
 
-       /* List<RaceDTO> races = Arrays.asList(
-                modelMapper.map(race,RaceDTO.class),
-                modelMapper.map(plannedRace1,RaceDTO.class),
-                modelMapper.map(plannedRace2,RaceDTO.class));
 
-*/
-        //  when(raceService.findAll()).thenReturn(races);
 
         mvc.perform(get("/api/races")
                         .contentType(MediaType.APPLICATION_JSON)
                         .param("open","true"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$", hasSize(2)));
-        //     .andExpect(jsonPath("$[0].date", MAYOR QUE HOY));
+
 
 
     }

--- a/your-race/src/test/java/es/codeurjc/mastercloudapps/your_race/usecase/AthleteUseCaseTest.java
+++ b/your-race/src/test/java/es/codeurjc/mastercloudapps/your_race/usecase/AthleteUseCaseTest.java
@@ -80,7 +80,7 @@ public class AthleteUseCaseTest extends AbstractDatabaseTest {
         mvc.perform(get("/api/races/planned")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$", hasSize(3)));
+                .andExpect(jsonPath("$", hasSize(2)));
         //     .andExpect(jsonPath("$[0].date", MAYOR QUE HOY));
 
 

--- a/your-race/src/test/java/es/codeurjc/mastercloudapps/your_race/usecase/AthleteUseCaseTest.java
+++ b/your-race/src/test/java/es/codeurjc/mastercloudapps/your_race/usecase/AthleteUseCaseTest.java
@@ -77,8 +77,9 @@ public class AthleteUseCaseTest extends AbstractDatabaseTest {
 */
         //  when(raceService.findAll()).thenReturn(races);
 
-        mvc.perform(get("/api/races/planned")
-                        .contentType(MediaType.APPLICATION_JSON))
+        mvc.perform(get("/api/races")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .param("open","true"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$", hasSize(2)));
         //     .andExpect(jsonPath("$[0].date", MAYOR QUE HOY));

--- a/your-race/src/test/java/es/codeurjc/mastercloudapps/your_race/usecase/AthleteUseCaseTest.java
+++ b/your-race/src/test/java/es/codeurjc/mastercloudapps/your_race/usecase/AthleteUseCaseTest.java
@@ -1,0 +1,110 @@
+package es.codeurjc.mastercloudapps.your_race.usecase;
+
+import com.github.javafaker.Faker;
+import es.codeurjc.mastercloudapps.your_race.AbstractDatabaseTest;
+import es.codeurjc.mastercloudapps.your_race.domain.Organizer;
+import es.codeurjc.mastercloudapps.your_race.domain.Race;
+import es.codeurjc.mastercloudapps.your_race.repos.OrganizerRepository;
+import es.codeurjc.mastercloudapps.your_race.repos.RaceRepository;
+import es.codeurjc.mastercloudapps.your_race.service.RaceService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@AutoConfigureMockMvc
+@SpringBootTest
+public class AthleteUseCaseTest extends AbstractDatabaseTest {
+    @Autowired
+    private MockMvc mvc;
+    @Autowired
+    private RaceService raceService;
+
+    @Autowired
+    private OrganizerRepository organizerRepository;
+
+    @Autowired
+    private RaceRepository raceRepository;
+
+    private Faker faker;
+    Organizer organizer;
+
+
+    @BeforeEach
+    public void initEach(){
+        faker = new Faker();
+        raceRepository.deleteAll();
+
+    }
+
+    @DisplayName("Get list of planned races (not celebrated yet)")
+    @Test
+    void shouldGetListPlannedRaces() throws Exception{
+
+        Organizer organizer = Organizer.builder().name("Test Organizer").build();
+        organizerRepository.save(organizer);
+
+        Race race = buildTestRace(organizer);
+        Race plannedRace1 = buildTestRace(organizer);
+        Race plannedRace2 = buildTestRace(organizer);
+
+
+        this.setDateInPast(race);
+        this.setDateInFuture(plannedRace1);
+        this.setDateInFuture(plannedRace2);
+
+        raceRepository.save(race);
+        raceRepository.save(plannedRace1);
+        raceRepository.save(plannedRace2);
+
+       /* List<RaceDTO> races = Arrays.asList(
+                modelMapper.map(race,RaceDTO.class),
+                modelMapper.map(plannedRace1,RaceDTO.class),
+                modelMapper.map(plannedRace2,RaceDTO.class));
+
+*/
+        //  when(raceService.findAll()).thenReturn(races);
+
+        mvc.perform(get("/api/races/planned")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(3)));
+        //     .andExpect(jsonPath("$[0].date", MAYOR QUE HOY));
+
+
+    }
+
+    Race buildTestRace(Organizer organizer){
+        return Race.builder()
+                .name(faker.esports().event())
+                .description("A race for testing")
+                .location(faker.address().cityName())
+                .distance(faker.number().randomDouble(2,0,1000))
+                .organizer(organizer)
+                .build();
+    }
+    void setDateInFuture(Race race){
+
+        race.setDate(LocalDateTime.of(LocalDate.now().getYear(), LocalDate.now().getMonth().plus(4),1,9,0));
+
+    }
+
+    void setDateInPast(Race race){
+
+        race.setDate(LocalDateTime.of(LocalDate.now().getYear(), LocalDate.now().getMonth().minus(1),1,9,0));
+
+    }
+
+ }

--- a/your-race/src/test/java/es/codeurjc/mastercloudapps/your_race/usecase/AthleteUseCaseTest.java
+++ b/your-race/src/test/java/es/codeurjc/mastercloudapps/your_race/usecase/AthleteUseCaseTest.java
@@ -80,7 +80,7 @@ public class AthleteUseCaseTest extends AbstractDatabaseTest {
         mvc.perform(get("/api/races/planned")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$", hasSize(0)));
+                .andExpect(jsonPath("$", hasSize(3)));
         //     .andExpect(jsonPath("$[0].date", MAYOR QUE HOY));
 
 

--- a/your-race/src/test/java/es/codeurjc/mastercloudapps/your_race/usecase/AthleteUseCaseTest.java
+++ b/your-race/src/test/java/es/codeurjc/mastercloudapps/your_race/usecase/AthleteUseCaseTest.java
@@ -80,7 +80,7 @@ public class AthleteUseCaseTest extends AbstractDatabaseTest {
         mvc.perform(get("/api/races/planned")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$", hasSize(3)));
+                .andExpect(jsonPath("$", hasSize(0)));
         //     .andExpect(jsonPath("$[0].date", MAYOR QUE HOY));
 
 

--- a/your-race/src/test/java/es/codeurjc/mastercloudapps/your_race/usecase/AthleteUseCaseTest.java
+++ b/your-race/src/test/java/es/codeurjc/mastercloudapps/your_race/usecase/AthleteUseCaseTest.java
@@ -97,13 +97,15 @@ public class AthleteUseCaseTest extends AbstractDatabaseTest {
     }
     void setDateInFuture(Race race){
 
-        race.setDate(LocalDateTime.of(LocalDate.now().getYear(), LocalDate.now().getMonth().plus(4),1,9,0));
+        LocalDateTime date = LocalDateTime.now().plusMonths(4L);
+        race.setDate(LocalDateTime.of(date.getYear(), date.getMonth(),1,9,0));
 
     }
 
     void setDateInPast(Race race){
 
-        race.setDate(LocalDateTime.of(LocalDate.now().getYear(), LocalDate.now().getMonth().minus(1),1,9,0));
+        LocalDateTime date = LocalDateTime.now().minusMonths(1L);
+        race.setDate(LocalDateTime.of(date.getYear(), date.getMonth(),1,9,0));
 
     }
 


### PR DESCRIPTION
1. Contiene el siguiente AC de Use Case Get Races (High priority-Medium relevance)  #26 
-- Any person can get the list of races not celebrated yet. (Añade parámetro en endpoint: races?open=).

3. Incluye la restauración de RaceTest.java anterior a la introducción de los Faker, ya que me daba el siguiente error:
2022-10-10 22:41:34.188 INFO 83599 --- [ main] e.c.m.y.rest.AthleteResourceTest : Starting AthleteResourceTest using Java 17.0.1 on tos with PID 83599 (started by rtoscano in /home/rtoscano/master/TFM/your-race/your-race)
2022-10-10 22:41:34.188 INFO 83599 --- [ main] e.c.m.y.rest.AthleteResourceTest : No active profile set, falling back to 1 default profile: "default"
2022-10-10 22:41:34.449 INFO 83599 --- [ main] .s.d.r.c.RepositoryConfigurationDelegate : Bootstrapping Spring Data JPA repositories in DEFAULT mode.
2022-10-10 22:41:34.461 INFO 83599 --- [ main] .s.d.r.c.RepositoryConfigurationDelegate : Finished Spring Data repository scanning in 11 ms. Found 7 JPA repository interfaces.
2022-10-10 22:41:34.889 INFO 83599 --- [ main] o.hibernate.jpa.internal.util.LogHelper : HHH000204: Processing PersistenceUnitInfo [name: default]
2022-10-10 22:41:34.893 INFO 83599 --- [ main] com.zaxxer.hikari.HikariDataSource : HikariPool-4 - Starting...
2022-10-10 22:41:34.914 INFO 83599 --- [ main] com.zaxxer.hikari.HikariDataSource : HikariPool-4 - Start completed.
2022-10-10 22:41:34.914 INFO 83599 --- [ main] org.hibernate.dialect.Dialect : HHH000400: Using dialect: org.hibernate.dialect.PostgreSQL10Dialect
2022-10-10 22:41:35.131 INFO 83599 --- [ main] o.h.e.t.j.p.i.JtaPlatformInitiator : HHH000490: Using JtaPlatform implementation: [org.hibernate.engine.transaction.jta.platform.internal.NoJtaPlatform]
2022-10-10 22:41:35.132 INFO 83599 --- [ main] j.LocalContainerEntityManagerFactoryBean : Initialized JPA EntityManagerFactory for persistence unit 'default'
2022-10-10 22:41:36.300 INFO 83599 --- [ main] o.s.b.t.m.w.SpringBootMockServletContext : Initializing Spring TestDispatcherServlet ''
2022-10-10 22:41:36.301 INFO 83599 --- [ main] o.s.t.web.servlet.TestDispatcherServlet : Initializing Servlet ''
2022-10-10 22:41:36.308 INFO 83599 --- [ main] o.s.b.a.e.web.EndpointLinksResolver : Exposing 14 endpoint(s) beneath base path '/actuator'
2022-10-10 22:41:36.328 INFO 83599 --- [ main] o.s.t.web.servlet.TestDispatcherServlet : Completed initialization in 27 ms
2022-10-10 22:41:36.371 INFO 83599 --- [ main] e.c.m.y.rest.AthleteResourceTest : Started AthleteResourceTest in 2.225 seconds (JVM running for 44.485)
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 5.342 s - in es.codeurjc.mastercloudapps.your_race.rest.AthleteResourceTest
[INFO] Running es.codeurjc.mastercloudapps.your_race.repos.AthleteRepositoryTest
2022-10-10 22:41:36.953 INFO 83599 --- [ main] o.s.t.c.support.AbstractContextLoader : Could not detect default resource locations for test class [es.codeurjc.mastercloudapps.your_race.AbstractDatabaseTest]: no resource found for suffixes {-context.xml, Context.groovy}.
2022-10-10 22:41:36.953 INFO 83599 --- [ main] t.c.s.AnnotationConfigContextLoaderUtils : Could not detect default configuration classes for test class [es.codeurjc.mastercloudapps.your_race.AbstractDatabaseTest]: AbstractDatabaseTest does not declare any static, non-private, non-final, nested classes annotated with @configuration.
2022-10-10 22:41:36.958 INFO 83599 --- [ main] .b.t.c.SpringBootTestContextBootstrapper : Found @SpringBootConfiguration es.codeurjc.mastercloudapps.your_race.YourRaceApplication for test class es.codeurjc.mastercloudapps.your_race.repos.AthleteRepositoryTest
2022-10-10 22:41:36.960 INFO 83599 --- [ main] .b.t.c.SpringBootTestContextBootstrapper : Loaded default TestExecutionListener class names from location [META-INF/spring.factories]: [org.springframework.boot.test.mock.mockito.MockitoTestExecutionListener, org.springframework.boot.test.mock.mockito.ResetMocksTestExecutionListener, org.springframework.boot.test.autoconfigure.restdocs.RestDocsTestExecutionListener, org.springframework.boot.test.autoconfigure.web.client.MockRestServiceServerResetTestExecutionListener, org.springframework.boot.test.autoconfigure.web.servlet.MockMvcPrintOnlyOnFailureTestExecutionListener, org.springframework.boot.test.autoconfigure.web.servlet.WebDriverTestExecutionListener, org.springframework.boot.test.autoconfigure.webservices.client.MockWebServiceServerTestExecutionListener, org.springframework.test.context.web.ServletTestExecutionListener, org.springframework.test.context.support.DirtiesContextBeforeModesTestExecutionListener, org.springframework.test.context.event.ApplicationEventsTestExecutionListener, org.springframework.test.context.support.DependencyInjectionTestExecutionListener, org.springframework.test.context.support.DirtiesContextTestExecutionListener, org.springframework.test.context.transaction.TransactionalTestExecutionListener, org.springframework.test.context.jdbc.SqlScriptsTestExecutionListener, org.springframework.test.context.event.EventPublishingTestExecutionListener]
2022-10-10 22:41:36.961 INFO 83599 --- [ main] .b.t.c.SpringBootTestContextBootstrapper : Using TestExecutionListeners: [org.springframework.test.context.web.ServletTestExecutionListener@41040abf, org.springframework.test.context.support.DirtiesContextBeforeModesTestExecutionListener@2012a36c, org.springframework.test.context.event.ApplicationEventsTestExecutionListener@2f949bf0, org.springframework.boot.test.mock.mockito.MockitoTestExecutionListener@3cdc43b, org.springframework.boot.test.autoconfigure.SpringBootDependencyInjectionTestExecutionListener@627d770f, org.springframework.test.context.support.DirtiesContextTestExecutionListener@57c1b1ef, org.springframework.test.context.transaction.TransactionalTestExecutionListener@5c01fbfc, org.springframework.test.context.jdbc.SqlScriptsTestExecutionListener@3100005b, org.springframework.test.context.event.EventPublishingTestExecutionListener@384cdc7b, org.springframework.boot.test.mock.mockito.ResetMocksTestExecutionListener@62d85c54, org.springframework.boot.test.autoconfigure.restdocs.RestDocsTestExecutionListener@315585e8, org.springframework.boot.test.autoconfigure.web.client.MockRestServiceServerResetTestExecutionListener@e64941, org.springframework.boot.test.autoconfigure.web.servlet.MockMvcPrintOnlyOnFailureTestExecutionListener@5e17e222, org.springframework.boot.test.autoconfigure.web.servlet.WebDriverTestExecutionListener@7e0d2f48, org.springframework.boot.test.autoconfigure.webservices.client.MockWebServiceServerTestExecutionListener@636a9fa4]
2022-10-10 22:41:36.962 INFO 83599 --- [ main] whale [postgres:14.5] : Creating container for image: postgres:14.5
2022-10-10 22:41:37.086 INFO 83599 --- [ main] whale [postgres:14.5] : Starting container with ID: ffa77770e6783d106dee7830fab72b825b7519f278f139262f0185b0b9b07dd3
2022-10-10 22:41:37.594 INFO 83599 --- [ main] whale [postgres:14.5] : Container postgres:14.5 is starting: ffa77770e6783d106dee7830fab72b825b7519f278f139262f0185b0b9b07dd3
2022-10-10 22:41:39.471 INFO 83599 --- [ main] whale [postgres:14.5] : Container postgres:14.5 started in PT2.509458491S
2022-10-10 22:41:39.480 WARN 83599 --- [ main] com.zaxxer.hikari.pool.PoolBase : HikariPool-2 - Failed to validate connection org.postgresql.jdbc.PgConnection@62686d48 (This connection has been closed.). Possibly consider using a shorter maxLifetime value.
2022-10-10 22:41:39.483 WARN 83599 --- [ main] com.zaxxer.hikari.pool.PoolBase : HikariPool-2 - Failed to validate connection org.postgresql.jdbc.PgConnection@3925b21f (This connection has been closed.). Possibly consider using a shorter maxLifetime value.
2022-10-10 22:41:39.483 WARN 83599 --- [ main] com.zaxxer.hikari.pool.PoolBase : HikariPool-2 - Failed to validate connection org.postgresql.jdbc.PgConnection@18869a5e (This connection has been closed.). Possibly consider using a shorter maxLifetime value.
2022-10-10 22:41:39.484 WARN 83599 --- [ main] com.zaxxer.hikari.pool.PoolBase : HikariPool-2 - Failed to validate connection org.postgresql.jdbc.PgConnection@14cb3d57 (This connection has been closed.). Possibly consider using a shorter maxLifetime value.
2022-10-10 22:41:39.486 WARN 83599 --- [ main] com.zaxxer.hikari.pool.PoolBase : HikariPool-2 - Failed to validate connection org.postgresql.jdbc.PgConnection@7cedb6af (This connection has been closed.). Possibly consider using a shorter maxLifetime value.
2022-10-10 22:41:39.487 WARN 83599 --- [ main] com.zaxxer.hikari.pool.PoolBase : HikariPool-2 - Failed to validate connection org.postgresql.jdbc.PgConnection@684c4667 (This connection has been closed.). Possibly consider using a shorter maxLifetime value.
2022-10-10 22:41:39.488 WARN 83599 --- [ main] com.zaxxer.hikari.pool.PoolBase : HikariPool-2 - Failed to validate connection org.postgresql.jdbc.PgConnection@44b4755a (This connection has been closed.). Possibly consider using a shorter maxLifetime value.
2022-10-10 22:41:39.489 WARN 83599 --- [ main] com.zaxxer.hikari.pool.PoolBase : HikariPool-2 - Failed to validate connection org.postgresql.jdbc.PgConnection@9d8c91e (This connection has been closed.). Possibly consider using a shorter maxLifetime value.
2022-10-10 22:41:39.490 WARN 83599 --- [ main] com.zaxxer.hikari.pool.PoolBase : HikariPool-2 - Failed to validate connection org.postgresql.jdbc.PgConnection@18914e44 (This connection has been closed.). Possibly consider using a shorter maxLifetime value.
2022-10-10 22:41:39.491 WARN 83599 --- [ main] com.zaxxer.hikari.pool.PoolBase : HikariPool-2 - Failed to validate connection org.postgresql.jdbc.PgConnection@12e45c4f (This connection has been closed.). Possibly consider using a shorter maxLifetime value.
2022-10-10 22:42:09.483 WARN 83599 --- [ main] o.h.engine.jdbc.spi.SqlExceptionHelper : SQL Error: 0, SQLState: 08001
2022-10-10 22:42:09.484 ERROR 83599 --- [ main] o.h.engine.jdbc.spi.SqlExceptionHelper : HikariPool-2 - Connection is not available, request timed out after 30002ms.
2022-10-10 22:42:09.485 ERROR 83599 --- [ main] o.h.engine.jdbc.spi.SqlExceptionHelper : Connection to localhost:49246 refused. Check that the hostname and port are correct and that the postmaster is accepting TCP/IP connections.
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 33.089 s <<< FAILURE! - in es.codeurjc.mastercloudapps.your_race.repos.AthleteRepositoryTest
[ERROR] test Time elapsed: 30.055 s <<< ERROR!
org.springframework.transaction.CannotCreateTransactionException: Could not open JPA EntityManager for transaction; nested exception is org.hibernate.exception.JDBCConnectionException: Unable to acquire JDBC Connection
at es.codeurjc.mastercloudapps.your_race.repos.AthleteRepositoryTest.test(AthleteRepositoryTest.java:21)
Caused by: org.hibernate.exception.JDBCConnectionException: Unable to acquire JDBC Connection
at es.codeurjc.mastercloudapps.your_race.repos.AthleteRepositoryTest.test(AthleteRepositoryTest.java:21)
Caused by: java.sql.SQLTransientConnectionException: HikariPool-2 - Connection is not available, request timed out after 30002ms.
at es.codeurjc.mastercloudapps.your_race.repos.AthleteRepositoryTest.test(AthleteRepositoryTest.java:21)
Caused by: org.postgresql.util.PSQLException: Connection to localhost:49246 refused. Check that the hostname and port are correct and that the postmaster is accepting TCP/IP connections.
Caused by: java.net.ConnectException: Connection refused

2022-10-10 22:42:10.102 INFO 83599 --- [ionShutdownHook] j.LocalContainerEntityManagerFactoryBean : Closing JPA EntityManagerFactory for persistence unit 'default'
2022-10-10 22:42:10.104 INFO 83599 --- [ionShutdownHook] com.zaxxer.hikari.HikariDataSource : HikariPool-1 - Shutdown initiated...
2022-10-10 22:42:10.123 INFO 83599 --- [ionShutdownHook] com.zaxxer.hikari.HikariDataSource : HikariPool-1 - Shutdown completed.
2022-10-10 22:42:10.129 INFO 83599 --- [ionShutdownHook] j.LocalContainerEntityManagerFactoryBean : Closing JPA EntityManagerFactory for persistence unit 'default'
2022-10-10 22:42:10.130 INFO 83599 --- [ionShutdownHook] com.zaxxer.hikari.HikariDataSource : HikariPool-2 - Shutdown initiated...
2022-10-10 22:42:17.808 INFO 83599 --- [ionShutdownHook] com.zaxxer.hikari.HikariDataSource : HikariPool-2 - Shutdown completed.
2022-10-10 22:42:17.826 INFO 83599 --- [ionShutdownHook] j.LocalContainerEntityManagerFactoryBean : Closing JPA EntityManagerFactory for persistence unit 'default'
2022-10-10 22:42:17.830 INFO 83599 --- [ionShutdownHook] com.zaxxer.hikari.HikariDataSource : HikariPool-3 - Shutdown initiated...
2022-10-10 22:42:17.838 INFO 83599 --- [ionShutdownHook] com.zaxxer.hikari.HikariDataSource : HikariPool-3 - Shutdown completed.
2022-10-10 22:42:17.850 INFO 83599 --- [ionShutdownHook] j.LocalContainerEntityManagerFactoryBean : Closing JPA EntityManagerFactory for persistence unit 'default'
2022-10-10 22:42:17.852 INFO 83599 --- [ionShutdownHook] com.zaxxer.hikari.HikariDataSource : HikariPool-4 - Shutdown initiated...
2022-10-10 22:42:17.855 INFO 83599 --- [ionShutdownHook] com.zaxxer.hikari.HikariDataSource : HikariPool-4 - Shutdown completed.
[INFO]
[INFO] Results:
[INFO]
[ERROR] Errors:
[ERROR] AthleteRepositoryTest.test:21 » CannotCreateTransaction Could not open JPA Ent...
[INFO]
[ERROR] Tests run: 15, Failures: 0, Errors: 1, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 01:37 min
[INFO] Finished at: 2022-10-10T22:42:18+02:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:2.22.2:test (default-test) on project your-race: There are test failures.
[ERROR]
[ERROR] Please refer to /home/rtoscano/master/TFM/your-race/your-race/target/surefire-reports for the individual test results.
[ERROR] Please refer to dump files (if any exist) [date].dump, [date]-jvmRun[N].dump and [date].dumpstream.
[ERROR] -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException